### PR TITLE
fix: 予約処理完了時、親テーブルのステータスが変更されないバグを修正

### DIFF
--- a/main_app/views/twilio.py
+++ b/main_app/views/twilio.py
@@ -1,4 +1,5 @@
 import datetime
+from django.utils import timezone
 from zoneinfo import ZoneInfo
 from django.http import HttpResponse, HttpResponseRedirect
 from django.views import View
@@ -30,12 +31,12 @@ class TwilioButtonView(View):
         n_month = n_datetime.month
         n_day = n_datetime.day
 
-        message = f"こんにちは、電話予約の代理アプリ、Telyです。"
+        message = f"こんにちは、電話予約の代理アプリ、テリーです。"
 
         if n_year == r_year and n_month == r_month and n_day == r_day:
             message += f"本日の"
         elif n_year == r_year and n_month == r_month:
-            message += f"今月{r_day}日の"
+            message += f"こんげつ{r_day}日の"
         elif n_year == r_year:
             message += f"{r_month}月{r_day}日の"
         else:
@@ -106,7 +107,8 @@ class HandleButtonView(View):
                 message = '代理予約処理が完了しました。'
             )
 
-            obj_parent.status = ReservationParent.END
+            obj_parent.is_end = True
+            obj_parent.end_datetime = timezone.now
             obj_parent.save()
 
         elif digit_pressed == "2":
@@ -127,7 +129,8 @@ class HandleButtonView(View):
                 message = '代理予約処理が完了しました。'
             )
 
-            obj_parent.status = ReservationParent.END
+            obj_parent.is_end = True
+            obj_parent.end_datetime = timezone.now
             obj_parent.save()
 
         else:


### PR DESCRIPTION
## Ticket / Issue Number

- チケットなし

## What's changed

- 予約処理完了時、親テーブルのステータスが変更されないバグを修正しました（２回目）

## Todo List

## Check List

- [x] エラーや警告は出ませんでした
- [x] `docker-compose -f docker-compose.dev.yml up -d`を使ってコンテナの起動を確認しました
- [x] 開発環境で`localhost:8000`にアクセスしてサイトの動作確認を行いました

## Remark
