### PR TITLE
fix: トップページの店舗情報の価格帯が情報なしになってしまうバグを修正

### DIFF
--- a/templates/main_app/index.html
+++ b/templates/main_app/index.html
@@ -256,15 +256,15 @@ Top Page
                             </h6>
                             <h6 class="card-subtitle mb-2 text-muted">
                               価格帯<i class="bi bi-currency-yen"></i> : 
-                              {% if store.price_level == 0 %}
+                              {% if store.price_level == "0" %}
                               無料
-                              {% elif store.price_level == 1 %}
+                              {% elif store.price_level == "1" %}
                               安価
-                              {% elif store.price_level == 2 %}
+                              {% elif store.price_level == "2" %}
                               中程度
-                              {% elif store.price_level == 3 %}
+                              {% elif store.price_level == "3" %}
                               高価
-                              {% elif store.price_level == 4 %}
+                              {% elif store.price_level == "4" %}
                               非常に高価
                               {% else %}
                               情報なし


### PR DESCRIPTION
## Ticket / Issue Number

- チケットなし

## What's changed

- トップページの店舗情報の価格帯が情報なしになってしまうバグを修正しました

## Todo List


## Check List

- [x] エラーや警告は出ませんでした
- [x] `docker-compose -f docker-compose.dev.yml up -d`を使ってコンテナの起動を確認しました
- [x] 開発環境で`localhost:8000`にアクセスしてサイトの動作確認を行いました

## Remark
